### PR TITLE
Added Wrapper for annotations to allow simpler reading of annotations.

### DIFF
--- a/annotationprocessor/src/main/java/io/toolisticon/annotationprocessortoolkit/tools/AnnotationUtils.java
+++ b/annotationprocessor/src/main/java/io/toolisticon/annotationprocessortoolkit/tools/AnnotationUtils.java
@@ -183,6 +183,18 @@ public final class AnnotationUtils {
     public static TypeMirror getClassAttributeFromAnnotationAsTypeMirror(Element element, Class<? extends Annotation> annotationType, String attributeName) {
 
         AnnotationMirror annotationMirror = getAnnotationMirror(element, annotationType);
+        return getClassAttributeFromAnnotationAsTypeMirror(annotationMirror, attributeName);
+
+    }
+
+    /**
+     * Gets the a TypeMirror of a Class based attribute from annotation.
+     *
+     * @param annotationMirror the annotation mirror to get the TypeMirror from
+     * @return the TypeMirror of the searched annotation value or null if annotation can't be found or attribute isn't of type class.
+     */
+    public static TypeMirror getClassAttributeFromAnnotationAsTypeMirror(AnnotationMirror annotationMirror, String attributeName) {
+
         if (annotationMirror == null) {
             return null;
         }
@@ -258,7 +270,21 @@ public final class AnnotationUtils {
      */
     public static String[] getClassArrayAttributeFromAnnotationAsFqn(Element element, Class<? extends Annotation> annotationType, String attributeName) {
 
-        TypeMirror[] typeMirrorArray = getClassArrayAttributeFromAnnotationAsTypeMirror(element, annotationType, attributeName);
+        AnnotationMirror annotationMirror = getAnnotationMirror(element, annotationType);
+        return getClassArrayAttributeFromAnnotationAsFqn(annotationMirror, attributeName);
+
+    }
+
+    /**
+     * Gets class array attribute from annotations attributeName attribute as an array of full qualified class names.
+     *
+     * @param annotationMirror the annotation type
+     * @param attributeName    the name of the attribute
+     * @return The full qualified class name array of the attribute
+     */
+    public static String[] getClassArrayAttributeFromAnnotationAsFqn(AnnotationMirror annotationMirror, String attributeName) {
+
+        TypeMirror[] typeMirrorArray = getClassArrayAttributeFromAnnotationAsTypeMirror(annotationMirror, attributeName);
         String[] result = null;
 
         if (typeMirrorArray != null) {
@@ -296,6 +322,19 @@ public final class AnnotationUtils {
     public static TypeMirror[] getClassArrayAttributeFromAnnotationAsTypeMirror(Element element, Class<? extends Annotation> annotationType, String attributeName) {
 
         AnnotationMirror annotationMirror = getAnnotationMirror(element, annotationType);
+        return getClassArrayAttributeFromAnnotationAsTypeMirror(annotationMirror, attributeName);
+
+    }
+
+    /**
+     * Gets class array attribute from annotations attributeName attribute as an array of TypeMirrors.
+     *
+     * @param annotationMirror the annotation mirror
+     * @param attributeName    the name of the attribute
+     * @return The full qualified class name array of the attribute
+     */
+    public static TypeMirror[] getClassArrayAttributeFromAnnotationAsTypeMirror(AnnotationMirror annotationMirror, String attributeName) {
+
         if (annotationMirror == null) {
             return null;
         }
@@ -308,6 +347,5 @@ public final class AnnotationUtils {
         }
 
     }
-
 
 }

--- a/annotationwrapper/api/pom.xml
+++ b/annotationwrapper/api/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>annotationwrapper-api</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+        <artifactId>annotationwrapper-parent</artifactId>
+        <version>0.14.6-SNAPSHOT</version>
+    </parent>
+
+    <name>annotationwrapper-api</name>
+
+
+    <build>
+
+        <plugins>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+
+</project>

--- a/annotationwrapper/api/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/api/AnnotationWrapper.java
+++ b/annotationwrapper/api/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/api/AnnotationWrapper.java
@@ -1,0 +1,41 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.api;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to create a wrapper class for an annotation.
+ * The wrapper
+ */
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AnnotationWrapper {
+    /**
+     * The annotations to create wrappers for.
+     *
+     * @return
+     */
+    Class<? extends Annotation>[] value();
+
+    /**
+     * Configures to generate wrappers for all embedded annotations as well.
+     * Defaults to true.
+     *
+     * @return
+     */
+    boolean automaticallyWrapEmbeddedAnnotations() default true;
+
+    /**
+     * Configures to use public visibility for all wrappers.
+     * Package private visibility will be used, if set to false
+     * Defaults to false.
+     *
+     * @return
+     */
+    boolean usePublicVisibility() default false;
+}

--- a/annotationwrapper/integrationtest/pom.xml
+++ b/annotationwrapper/integrationtest/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>annotationwrapper-integrationTest</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+        <artifactId>annotationwrapper-parent</artifactId>
+        <version>0.14.6-SNAPSHOT</version>
+    </parent>
+
+    <name>annotationwrapper-integrationTest</name>
+
+
+    <dependencyManagement>
+
+    </dependencyManagement>
+
+
+    <build>
+
+        <pluginManagement>
+
+
+        </pluginManagement>
+
+        <plugins>
+
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration combine.children="append">
+                    <verbose>true</verbose>
+                    <source>${java.compile.source.version}</source>
+                    <target>${java.compile.target.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+                            <artifactId>annotationwrapper-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- revoke enforcer limitations for example -->
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.0.0,)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.6</version>
+                                </requireJavaVersion>
+                                <bannedDependencies>
+                                    <searchTransitive>false</searchTransitive>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+        </plugins>
+
+
+    </build>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+            <artifactId>annotationwrapper-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+            <artifactId>annotationprocessor</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+            <artifactId>cute</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.cute</groupId>
+            <artifactId>cute</artifactId>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/EmbeddedAnnotation.java
+++ b/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/EmbeddedAnnotation.java
@@ -1,0 +1,9 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmbeddedAnnotation {
+    long value();
+}

--- a/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/TestAnnotation.java
+++ b/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/TestAnnotation.java
@@ -1,0 +1,35 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import javax.lang.model.type.TypeKind;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TestAnnotation {
+
+    String stringAttribute();
+
+    long longAttribute();
+
+    double doubleAttribute();
+
+    Class<?> typeAttribute();
+
+    TestEnum enumAttribute();
+
+    EmbeddedAnnotation annotationAttribute();
+
+    String[] stringArrayAttribute() default {};
+
+    TestEnum[] enumArrayAttribute();
+
+    Class<?>[] typeArrayAttribute();
+
+    EmbeddedAnnotation[] annotationArrayAttribute();
+
+}

--- a/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/TestDefaultsAnnotation.java
+++ b/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/TestDefaultsAnnotation.java
@@ -1,0 +1,16 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestDefaultsAnnotation {
+
+    String withDefault() default "default";
+
+    String withoutDefault() default "notDefault";
+
+}

--- a/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/TestEnum.java
+++ b/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/TestEnum.java
@@ -1,0 +1,5 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+public enum TestEnum {
+    ONE, TWO, THREE;
+}

--- a/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/package-info.java
+++ b/annotationwrapper/integrationtest/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/package-info.java
@@ -1,0 +1,7 @@
+@AnnotationWrapper(value = {TestAnnotation.class, TestDefaultsAnnotation.class}, automaticallyWrapEmbeddedAnnotations = true)
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import io.toolisticon.annotationprocessortoolkit.wrapper.api.AnnotationWrapper;
+
+
+

--- a/annotationwrapper/integrationtest/src/test/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/IntegrationTest.java
+++ b/annotationwrapper/integrationtest/src/test/java/io/toolisticon/annotationprocessortoolkit/wrapper/test/IntegrationTest.java
@@ -1,0 +1,110 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import io.toolisticon.annotationprocessortoolkit.cute.APTKUnitTestProcessor;
+import io.toolisticon.annotationprocessortoolkit.tools.AnnotationUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.MessagerUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.TypeMirrorWrapper;
+import io.toolisticon.cute.CompileTestBuilder;
+import io.toolisticon.cute.PassIn;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Integration Test to test correctness of generated code
+ */
+public class IntegrationTest {
+
+    CompileTestBuilder.UnitTestBuilder unitTestBuilder = CompileTestBuilder.unitTest();
+
+    @Before
+    public void init() {
+        MessagerUtils.setPrintMessageCodes(true);
+
+    }
+
+    @PassIn
+    @TestAnnotation(
+            stringAttribute = "WTF",
+            doubleAttribute = 1.0,
+            longAttribute = 1L,
+            enumAttribute = TestEnum.TWO,
+            typeAttribute = String.class,
+            annotationAttribute = @EmbeddedAnnotation(1),
+            stringArrayAttribute = {"1", "2", "3"},
+            typeArrayAttribute = {Long.class, String.class},
+            enumArrayAttribute = {TestEnum.TWO, TestEnum.THREE},
+            annotationArrayAttribute = {@EmbeddedAnnotation(1), @EmbeddedAnnotation(2)}
+
+    )
+    public static class TestUsage {
+    }
+
+    @Test
+    public void testWrappedAccess() {
+        unitTestBuilder.defineTestWithPassedInElement(TestUsage.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                // single attribute values
+                TestAnnotationWrapper testAnnotationWrapper = TestAnnotationWrapper.wrapAnnotationOfElement(typeElement);
+                MatcherAssert.assertThat(testAnnotationWrapper.stringAttribute(), Matchers.is("WTF"));
+                MatcherAssert.assertThat(testAnnotationWrapper.doubleAttribute(), Matchers.is(1.0));
+                MatcherAssert.assertThat(testAnnotationWrapper.longAttribute(), Matchers.is(1L));
+                MatcherAssert.assertThat(testAnnotationWrapper.enumAttribute(), Matchers.is(TestEnum.TWO));
+                MatcherAssert.assertThat(testAnnotationWrapper.typeAttributeAsFqn(), Matchers.is(String.class.getCanonicalName()));
+                MatcherAssert.assertThat(testAnnotationWrapper.typeAttributeAsTypeMirror().toString(), Matchers.is(String.class.getCanonicalName()));
+                MatcherAssert.assertThat(testAnnotationWrapper.typeAttributeAsTypeMirrorWrapper().getQualifiedName(), Matchers.is(String.class.getCanonicalName()));
+                MatcherAssert.assertThat((Long) AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(testAnnotationWrapper.annotationAttributeAsAnnotationMirror()).getValue(), Matchers.is(1L));
+                MatcherAssert.assertThat(testAnnotationWrapper.annotationAttribute().value(), Matchers.is(1L));
+
+                // array based attribute values
+                MatcherAssert.assertThat(testAnnotationWrapper.stringArrayAttribute(), Matchers.arrayContaining("1", "2", "3"));
+                MatcherAssert.assertThat(testAnnotationWrapper.typeArrayAttributeAsFqn(), Matchers.arrayContaining(Long.class.getCanonicalName(), String.class.getCanonicalName()));
+                TypeMirror[] typeMirrorArray = testAnnotationWrapper.typeArrayAttributeAsTypeMirror();
+                MatcherAssert.assertThat(typeMirrorArray[0].toString(), Matchers.is(Long.class.getCanonicalName()));
+                MatcherAssert.assertThat(typeMirrorArray[1].toString(), Matchers.is(String.class.getCanonicalName()));
+                TypeMirrorWrapper[] typeMirrorWrapperArray = testAnnotationWrapper.typeArrayAttributeAsTypeMirrorWrapper();
+                MatcherAssert.assertThat(typeMirrorWrapperArray[0].getQualifiedName(), Matchers.is(Long.class.getCanonicalName()));
+                MatcherAssert.assertThat(typeMirrorWrapperArray[1].getQualifiedName(), Matchers.is(String.class.getCanonicalName()));
+                MatcherAssert.assertThat(testAnnotationWrapper.enumArrayAttribute(), Matchers.arrayContaining(TestEnum.TWO, TestEnum.THREE));
+                AnnotationMirror[] annotationMirrors = testAnnotationWrapper.annotationArrayAttributeAsAnnotationMirrorArray();
+                MatcherAssert.assertThat((Long) AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirrors[0]).getValue(), Matchers.is(1L));
+                MatcherAssert.assertThat((Long) AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirrors[1]).getValue(), Matchers.is(2L));
+                EmbeddedAnnotationWrapper[] embeddedAnnotationWrappers = testAnnotationWrapper.annotationArrayAttribute();
+                MatcherAssert.assertThat(embeddedAnnotationWrappers[0].value(), Matchers.is(1L));
+                MatcherAssert.assertThat(embeddedAnnotationWrappers[1].value(), Matchers.is(2L));
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    @PassIn
+    @TestDefaultsAnnotation(withoutDefault = "ABC")
+    public static class DefaultTestCase {
+
+    }
+
+    @Test
+    public void testDefaultValueDetection() {
+        unitTestBuilder.defineTestWithPassedInElement(DefaultTestCase.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                // single attribute values
+                TestDefaultsAnnotationWrapper wrappedAnnotation = TestDefaultsAnnotationWrapper.wrapAnnotationOfElement(typeElement);
+                MatcherAssert.assertThat(wrappedAnnotation.withDefaultIsDefaultValue(), Matchers.is(true));
+                MatcherAssert.assertThat(wrappedAnnotation.withoutDefaultIsDefaultValue(), Matchers.is(false));
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+}

--- a/annotationwrapper/pom.xml
+++ b/annotationwrapper/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>annotationwrapper-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>annotationwrapper-parent</name>
+
+    <parent>
+        <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+        <artifactId>annotationprocessortoolkit-parent</artifactId>
+        <version>0.14.6-SNAPSHOT</version>
+    </parent>
+
+
+    <modules>
+        <module>api</module>
+        <module>processor</module>
+        <module>integrationtest</module>
+    </modules>
+
+
+    <dependencies>
+
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- internal -->
+            <dependency>
+                <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+                <artifactId>annotationwrapper-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+                <artifactId>annotationwrapper-processor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+                <artifactId>cute</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.toolisticon.spiap</groupId>
+                <artifactId>spiap-api</artifactId>
+                <version>${spiap.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/annotationwrapper/processor/pom.xml
+++ b/annotationwrapper/processor/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>annotationwrapper-processor</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+        <artifactId>annotationwrapper-parent</artifactId>
+        <version>0.14.6-SNAPSHOT</version>
+    </parent>
+
+    <name>annotationwrapper-processor</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+            <artifactId>annotationwrapper-api</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+            <artifactId>annotationprocessor</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.annotationprocessortoolkit</groupId>
+            <artifactId>cute</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.spiap</groupId>
+            <artifactId>spiap-api</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.toolisticon.spiap</groupId>
+            <artifactId>spiap-processor</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.toolisticon.cute</groupId>
+            <artifactId>cute</artifactId>
+        </dependency>
+
+
+    </dependencies>
+
+
+    <build>
+
+        <plugins>
+
+
+            <!--
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+
+
+                        <configuration>
+
+
+
+
+
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.toolisticon.annotationprocessortoolkit</pattern>
+                                    <excludes>
+                                        <exclude>io.toolisticon.annotationprocessortoolkit.wrapper.*</exclude>
+                                    </excludes>
+                                    <shadedPattern>
+                                        io.toolisticon.annotationprocessortoolkit.wrapper_3rdparty.io.toolisticon.annotationprocessortoolkit.tools
+                                    </shadedPattern>
+                                </relocation>
+                            </relocations>
+
+                        </configuration>
+
+                    </execution>
+                </executions>
+
+
+            </plugin>
+            -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration combine.children="append">
+                    <verbose>true</verbose>
+                    <source>${java.compile.source.version}</source>
+                    <target>${java.compile.target.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.toolisticon.spiap</groupId>
+                            <artifactId>spiap-processor</artifactId>
+                            <version>${spiap.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+
+        </plugins>
+
+    </build>
+
+
+</project>

--- a/annotationwrapper/processor/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/AnnotationWrapperProcessor.java
+++ b/annotationwrapper/processor/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/AnnotationWrapperProcessor.java
@@ -1,0 +1,499 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.processor;
+
+import io.toolisticon.annotationprocessortoolkit.AbstractAnnotationProcessor;
+import io.toolisticon.annotationprocessortoolkit.tools.AnnotationUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.FilerUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.MessagerUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.TypeMirrorWrapper;
+import io.toolisticon.annotationprocessortoolkit.tools.TypeUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.corematcher.CoreMatchers;
+import io.toolisticon.annotationprocessortoolkit.tools.fluentfilter.FluentElementFilter;
+import io.toolisticon.annotationprocessortoolkit.tools.generators.SimpleJavaWriter;
+import io.toolisticon.annotationprocessortoolkit.wrapper.api.AnnotationWrapper;
+import io.toolisticon.spiap.api.Service;
+
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Annotation processor to generate wrapper class that eases reading of annotations attributes.
+ * This circumvents the need to read attribute values by AnnotationMirror/Value api.
+ */
+@Service(Processor.class)
+public class AnnotationWrapperProcessor extends AbstractAnnotationProcessor {
+
+    /**
+     * The supported annotation types.
+     */
+    private final static Set<String> SUPPORTED_ANNOTATIONS = createSupportedAnnotationSet(AnnotationWrapper.class);
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return SUPPORTED_ANNOTATIONS;
+    }
+
+    /**
+     * Stores processing state.
+     */
+    public static class State {
+
+        final PackageElement packageElement;
+        final Set<String> annotationsToBeWrapped = new HashSet<>();
+        final boolean usePublicVisibility;
+        final boolean automaticallyWrapEmbeddedAnnotations;
+
+
+        /**
+         * Constructor
+         *
+         * @param packageElement the base package name
+         */
+        State(PackageElement packageElement) {
+            this.packageElement = packageElement;
+
+            Collections.addAll(this.annotationsToBeWrapped, AnnotationUtils.getClassArrayAttributeFromAnnotationAsFqn(packageElement, AnnotationWrapper.class));
+
+            AnnotationMirror annotationMirror = AnnotationUtils.getAnnotationMirror(packageElement, AnnotationWrapper.class);
+            usePublicVisibility = (Boolean) AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "usePublicVisibility").getValue();
+            automaticallyWrapEmbeddedAnnotations = (Boolean) AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "automaticallyWrapEmbeddedAnnotations").getValue();
+
+            // now recursively add all embedded annotations
+            if (automaticallyWrapEmbeddedAnnotations) {
+                for (String annotationFqn : new ArrayList<>(annotationsToBeWrapped)) {
+                    recursivelyAddAnnotations(annotationFqn);
+                }
+            }
+
+        }
+
+        /**
+         * Recursively determines all embedded annotation types
+         *
+         * @param annotationFqn The annotation to scan
+         */
+        private void recursivelyAddAnnotations(String annotationFqn) {
+
+            TypeElement element = TypeUtils.TypeRetrieval.getTypeElement(annotationFqn);
+
+            for (ExecutableElement executableElement : FluentElementFilter.createFluentElementFilter(element.getEnclosedElements()).applyFilter(CoreMatchers.IS_METHOD).getResult()) {
+
+                TypeMirror returnTypeMirror = executableElement.getReturnType();
+                String returnTypeFqn = TypeMirrorWrapper.wrap(returnTypeMirror).getQualifiedName();
+                if (
+                        TypeKind.DECLARED.equals(returnTypeMirror.getKind())
+                                && ElementKind.ANNOTATION_TYPE.equals(TypeUtils.TypeRetrieval.getTypeElement(returnTypeMirror).getKind())
+                                && !this.annotationsToBeWrapped.contains(returnTypeFqn)
+                ) {
+                    this.annotationsToBeWrapped.add(returnTypeFqn);
+                    recursivelyAddAnnotations(returnTypeFqn);
+                }
+
+            }
+
+        }
+
+        /**
+         * Gets the PackageElement used during wrapper generation
+         *
+         * @return The PackageElement
+         */
+        public PackageElement getPackageElement() {
+            return this.packageElement;
+        }
+
+        /**
+         * Gets the package name used during wrapper generation
+         *
+         * @return The package name
+         */
+        public String getPackageName() {
+            return this.packageElement.getQualifiedName().toString();
+        }
+
+        public Set<String> getAnnotationToBeWrapped() {
+            return annotationsToBeWrapped;
+        }
+
+        public boolean containsAnnotationToBeWrapped(String annotationFqn) {
+            return annotationsToBeWrapped.contains(annotationFqn);
+        }
+
+        public String getWrapperName(String annotationFqn) {
+            return TypeMirrorWrapper.wrap(TypeUtils.TypeRetrieval.getTypeMirror(annotationFqn)).getSimpleName() + "Wrapper";
+        }
+
+        public boolean isUsePublicVisibility() {
+            return usePublicVisibility;
+        }
+
+    }
+
+    @Override
+    public boolean processAnnotations(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
+
+        // process Services annotation
+        for (Element element : roundEnv.getElementsAnnotatedWith(AnnotationWrapper.class)) {
+
+
+            PackageElement packageElement = (PackageElement) element;
+            State state = new State(packageElement);
+
+            // Now iterate over the annotation types and
+            for (String annotationToBeWrapped : state.getAnnotationToBeWrapped()) {
+                processAnnotationToBeWrapped(state, annotationToBeWrapped);
+            }
+
+
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Stores the configuration done in the {@see AnnotationToWrap} annotation.
+     * <p>
+     * In fact this is exactly a good example reason why this processor is needed.
+     */
+    public static class AnnotationToWrap {
+
+        /**
+         * the fully qualified name of the annotation
+         */
+        final String annotationFqn;
+
+        /**
+         * The attributes of the annotation
+         */
+        final List<AnnotationAttribute> attributes;
+
+        /**
+         * The constructor
+         *
+         * @param annotationFqn the fully qualified name of the annotation
+         * @param attributes    The attributes of the annotation
+         */
+        AnnotationToWrap(String annotationFqn, List<AnnotationAttribute> attributes) {
+            this.annotationFqn = annotationFqn;
+            this.attributes = attributes;
+        }
+
+        /**
+         * Gets the attributes of the annotation
+         *
+         * @return
+         */
+        public List<AnnotationAttribute> getAttributes() {
+            return this.attributes;
+        }
+
+        /**
+         * The simple name of the annotation
+         *
+         * @return
+         */
+        public String getSimpleName() {
+            return TypeUtils.TypeRetrieval.getTypeElement(annotationFqn).getSimpleName().toString();
+        }
+
+        /**
+         * The fully qualified name of the annotation.
+         *
+         * @return the fully qualified name
+         */
+        public String getQualifiedName() {
+            return TypeUtils.TypeRetrieval.getTypeElement(annotationFqn).getQualifiedName().toString();
+        }
+
+        /**
+         * Gets all imports needed by the annotation.
+         *
+         * @return
+         */
+        public List<String> getImports() {
+            List<String> imports = new ArrayList<>();
+
+            // first add the annotation itself
+            imports.add(getQualifiedName());
+
+            // now add all return types not starting with java.lang
+            for (AnnotationAttribute attribute : this.attributes) {
+                String importString = attribute.getImport();
+                if (importString != null && !importString.startsWith("java.lang")) {
+                    imports.add(attribute.getImport());
+                }
+            }
+
+            return imports;
+        }
+
+    }
+
+    /**
+     * Class to store information about an annotation attribute.
+     */
+    public static class AnnotationAttribute {
+
+        final ExecutableElement attribute;
+        final State state;
+
+        /**
+         * Constructor
+         *
+         * @param state     the processing state
+         * @param attribute The ExecutableElement that represents the attribute
+         */
+        AnnotationAttribute(State state, ExecutableElement attribute) {
+            this.state = state;
+            this.attribute = attribute;
+        }
+
+        /**
+         * Gets the attributes name
+         *
+         * @return
+         */
+        public String getName() {
+            return attribute.getSimpleName().toString();
+        }
+
+        public boolean isArray() {
+            return TypeKind.ARRAY == attribute.getReturnType().getKind();
+        }
+
+        /**
+         * Checks whether attribute is a primitive type or a String or not
+         *
+         * @return
+         */
+        public boolean isPrimitiveOrString() {
+
+            TypeMirror returnType = attribute.getReturnType();
+            if (isArray()) {
+                returnType = ((ArrayType) returnType).getComponentType();
+            }
+
+            // check for primitives
+            switch (returnType.getKind()) {
+                case INT:
+                case BYTE:
+                case LONG:
+                case CHAR:
+                case FLOAT:
+                case DOUBLE:
+                case BOOLEAN:
+                case SHORT:
+                    return true;
+                case DECLARED: {
+                    return (String.class.getCanonicalName().equals(returnType.toString()));
+                }
+
+            }
+
+            return false;
+
+        }
+
+        /**
+         * Checks whether attribute is enum type or not
+         *
+         * @return
+         */
+        public boolean isEnum() {
+
+            TypeMirror returnType = attribute.getReturnType();
+            if (isArray()) {
+                returnType = ((ArrayType) returnType).getComponentType();
+            }
+
+            return TypeKind.DECLARED.equals(returnType.getKind()) && ElementKind.ENUM.equals(TypeUtils.TypeRetrieval.getTypeElement(returnType).getKind());
+        }
+
+        /**
+         * Checks whether attribute is of type Class or not
+         *
+         * @return
+         */
+        public boolean isClass() {
+
+            TypeMirror returnType = attribute.getReturnType();
+            if (isArray()) {
+                returnType = ((ArrayType) returnType).getComponentType();
+            }
+
+            return TypeKind.DECLARED.equals(returnType.getKind()) && TypeUtils.TypeComparison.isTypeEqual(returnType, Class.class);
+        }
+
+        /**
+         * Checks whether attribute is an annotation type or not
+         *
+         * @return
+         */
+        public boolean isAnnotationType() {
+
+            TypeMirror returnType = attribute.getReturnType();
+            if (isArray()) {
+                returnType = ((ArrayType) returnType).getComponentType();
+            }
+
+            return TypeKind.DECLARED.equals(returnType.getKind()) && ElementKind.ANNOTATION_TYPE.equals(TypeUtils.TypeRetrieval.getTypeElement(returnType).getKind());
+        }
+
+        /**
+         * Checks if annotation type has an annotation wrapper implementation
+         *
+         * @return
+         */
+        public boolean isWrappedAnnotationType() {
+            return isAnnotationType() && state.containsAnnotationToBeWrapped(TypeMirrorWrapper.wrap(this.attribute.getReturnType()).getQualifiedName());
+        }
+
+        /**
+         * Gets the wrapped annotation name
+         *
+         * @return
+         */
+        public String getTargetWrapperAnnotationName() {
+            return state.getWrapperName(TypeMirrorWrapper.wrap(this.attribute.getReturnType()).getQualifiedName());
+        }
+
+        /**
+         * Checks if attribute is optional
+         *
+         * @return
+         */
+        public boolean isOptional() {
+            return this.attribute.getDefaultValue() != null;
+        }
+
+        /**
+         * Gets the import needed by this attribute
+         *
+         * @return will return the fqn of the attribute type. Will return null for primitive types and types residing in implicit java.lang package
+         */
+        public String getImport() {
+
+            TypeMirror typeMirror = attribute.getReturnType();
+
+            if (isArray()) {
+                typeMirror = ((ArrayType) attribute.getReturnType()).getComponentType();
+            }
+
+            if (typeMirror.getKind().isPrimitive()) {
+                return null;
+            }
+
+            // return null for String
+            String qualifiedName = TypeMirrorWrapper.wrap(typeMirror).getQualifiedName();
+            return qualifiedName.startsWith("java.lang") ? null : qualifiedName;
+        }
+
+        /**
+         * The attributes type as a simple name
+         *
+         * @return The attributes type as a simple name. Will return the component types simple name if attribute type is an array
+         */
+        public String getAttributeType() {
+            return TypeMirrorWrapper.wrap(attribute.getReturnType()).getSimpleName();
+        }
+
+        /**
+         * Gets the component type of an array
+         *
+         * @return the component type in case the attribute is an array, otherwise null
+         */
+        public String getComponentAttributeType() {
+            return TypeMirrorWrapper.wrap(attribute.getReturnType()).getWrappedComponentType().getSimpleName();
+        }
+
+        /**
+         * Gets the attributes wrapped TypeMirror
+         *
+         * @return The wrapped TypeMirror
+         */
+        public TypeMirrorWrapper getWrappedTypeMirror() {
+            return TypeMirrorWrapper.wrap(attribute.getReturnType());
+        }
+
+    }
+
+    /**
+     * Processes one annotation.
+     *
+     * @param state                        the processing state
+     * @param annotationToCreateWrapperFor The annotation to create a wrapper for as fqn
+     */
+    void processAnnotationToBeWrapped(State state, String annotationToCreateWrapperFor) {
+        // get annotation type first
+        TypeElement typeElement = TypeUtils.TypeRetrieval.getTypeElement(annotationToCreateWrapperFor);
+
+        // Now process all attributes
+        List<ExecutableElement> attributes = FluentElementFilter.createFluentElementFilter(typeElement.getEnclosedElements()).applyFilter(CoreMatchers.IS_METHOD).getResult();
+
+        List<AnnotationAttribute> annotationAttributes = new ArrayList<>();
+        for (ExecutableElement attribute : attributes) {
+
+            // Annotations may have different Attribute Types
+            // We have to distinct cases
+            // - primitive types and String (require no imports)
+            // - Enums (require imports)
+            // - Classes (require imports and extraction as fqn or TypeMirror)
+            // - Annotations (Must be replaced with wrappers, Need imports)
+            // - Arrays (of above)
+            annotationAttributes.add(new AnnotationAttribute(state, attribute));
+
+        }
+
+        AnnotationToWrap annotationToWrap = new AnnotationToWrap(annotationToCreateWrapperFor, annotationAttributes);
+
+        createClass(state, annotationToWrap);
+
+    }
+
+    /**
+     * Generates a wrapper class for one annotation.
+     * <p>
+     * Example how to use the templating engine.
+     * <p>
+     */
+
+    private void createClass(State state, AnnotationToWrap annotationToWrap) {
+
+        // Now create class
+
+        // Fill Model
+        Map<String, Object> model = new HashMap<>();
+        model.put("state", state);
+        model.put("atw", annotationToWrap);
+
+
+        // create the class
+        String filePath = state.getPackageName() + "." + annotationToWrap.getSimpleName() + "Wrapper";
+        try {
+            SimpleJavaWriter javaWriter = FilerUtils.createSourceFile(filePath, state.getPackageElement());
+            javaWriter.writeTemplate("/AnnotationWrapper.tpl", model);
+            javaWriter.close();
+        } catch (IOException e) {
+            MessagerUtils.error(state.getPackageElement(), AnnotationWrapperProcessorMessages.ERROR_CANT_CREATE_WRAPPER, annotationToWrap.getQualifiedName());
+        }
+    }
+
+}

--- a/annotationwrapper/processor/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/AnnotationWrapperProcessorMessages.java
+++ b/annotationwrapper/processor/src/main/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/AnnotationWrapperProcessorMessages.java
@@ -1,0 +1,48 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.processor;
+
+import io.toolisticon.annotationprocessortoolkit.tools.corematcher.ValidationMessage;
+
+public enum AnnotationWrapperProcessorMessages implements ValidationMessage {
+
+    ERROR_CANT_CREATE_WRAPPER("ANNOTATION_WRAPPER_ERROR_001", "Can't create wrapper class for Annotation ${0}");
+
+    /**
+     * the message code.
+     */
+    private final String code;
+    /**s
+     * the message text.
+     */
+    private final String message;
+
+    /**
+     * Constructor.
+     *
+     * @param code    the message code
+     * @param message the message text
+     */
+    AnnotationWrapperProcessorMessages(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    /**
+     * Gets the code of the message.
+     *
+     * @return the message code
+     */
+    public String getCode() {
+        return this.code;
+    }
+
+    /**
+     * Gets the message text.
+     *
+     * @return the message text
+     */
+    public String getMessage() {
+        return message;
+    }
+
+
+}

--- a/annotationwrapper/processor/src/main/resources/AnnotationWrapper.tpl
+++ b/annotationwrapper/processor/src/main/resources/AnnotationWrapper.tpl
@@ -1,0 +1,247 @@
+package ${state.packageName};
+!{for import : atw.imports}
+import ${import};
+!{/for}
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import java.util.ArrayList;
+import java.util.List;
+import io.toolisticon.annotationprocessortoolkit.tools.AnnotationUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.TypeMirrorWrapper;
+import io.toolisticon.annotationprocessortoolkit.tools.TypeUtils;
+
+
+/**
+ * Wrapper class to read attribute values from Annotation {@see ${atw.simpleName}}.
+ */
+!{if state.usePublicVisibility}public !{/if}class ${atw.simpleName}Wrapper {
+
+    private final Element annotatedElement;
+    private final AnnotationMirror annotationMirror;
+
+    /**
+     * Private constructor.
+     * Used to read annotation from Element.
+     */
+    private ${atw.simpleName}Wrapper (Element annotatedElement) {
+        this.annotatedElement = annotatedElement;
+        this.annotationMirror = AnnotationUtils.getAnnotationMirror(annotatedElement, ${atw.simpleName}.class);
+    }
+
+    /**
+     * Private constructor.
+     * Mainly used for embedded annotations.
+     */
+    private ${atw.simpleName}Wrapper (AnnotationMirror annotationMirror) {
+        this.annotatedElement = null;
+        this.annotationMirror = annotationMirror;
+    }
+
+!{for attribute : atw.attributes}
+!{if !attribute.isArray}!{if attribute.isPrimitiveOrString}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public ${attribute.attributeType} ${attribute.name}() {
+        return (${attribute.attributeType})AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue();
+    }
+!{/if}!{if attribute.isEnum}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public ${attribute.attributeType} ${attribute.name}() {
+        VariableElement enumValue = ((VariableElement)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue());
+        return ${attribute.attributeType}.valueOf(enumValue.getSimpleName().toString());
+    }
+!{/if}!{if attribute.isClass}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value as a TypeMirror
+     */
+    public TypeMirror ${attribute.name}AsTypeMirror() {
+        return (TypeMirror)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue();
+    }
+
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value as a TypeMirror
+     */
+    public TypeMirrorWrapper ${attribute.name}AsTypeMirrorWrapper() {
+        return TypeMirrorWrapper.wrap((TypeMirror)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue());
+    }
+
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value as a fqn
+     */
+    public String ${attribute.name}AsFqn() {
+        return TypeUtils.TypeConversion.convertToFqn(${attribute.name}AsTypeMirror());
+    }
+!{/if}!{if attribute.isAnnotationType}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public AnnotationMirror ${attribute.name}AsAnnotationMirror() {
+        return (AnnotationMirror)(AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue());
+    }
+
+!{if attribute.isWrappedAnnotationType}
+   /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public ${attribute.targetWrapperAnnotationName} ${attribute.name}() {
+        return ${attribute.targetWrapperAnnotationName}.wrapAnnotationMirror((AnnotationMirror)(AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue()));
+    }
+!{/if}!{/if}!{/if}!{if attribute.isArray}!{if attribute.isPrimitiveOrString}
+   /**
+    * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+    * @return the attribute value
+    */
+   public ${attribute.wrappedTypeMirror.getTypeDeclaration} ${attribute.name}() {
+
+       List<${attribute.getComponentAttributeType}> result = new ArrayList<>();
+       for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            result.add((${attribute.getComponentAttributeType})value.getValue());
+       }
+
+       return result.toArray(new ${attribute.getComponentAttributeType}[result.size()]);
+   }
+!{/if}!{if attribute.isEnum}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public ${attribute.wrappedTypeMirror.getTypeDeclaration} ${attribute.name}() {
+
+        List<${attribute.getComponentAttributeType}> result = new ArrayList<>();
+        for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            VariableElement enumValue = ((VariableElement)value.getValue());
+            result.add( ${attribute.getComponentAttributeType}.valueOf(enumValue.getSimpleName().toString()));
+        }
+
+        return result.toArray(new ${attribute.getComponentAttributeType}[result.size()]);
+    }
+!{/if}!{if attribute.isClass}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value as a TypeMirror
+     */
+    public TypeMirror[] ${attribute.name}AsTypeMirror() {
+
+        List<TypeMirror> result = new ArrayList<>();
+        for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            result.add( ((TypeMirror)value.getValue()));
+        }
+
+        return result.toArray(new TypeMirror[result.size()]);
+    }
+
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value as a TypeMirror
+     */
+    public TypeMirrorWrapper[] ${attribute.name}AsTypeMirrorWrapper() {
+
+        List<TypeMirrorWrapper> result = new ArrayList<>();
+        for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            result.add(TypeMirrorWrapper.wrap((TypeMirror)value.getValue()));
+        }
+
+        return result.toArray(new TypeMirrorWrapper[result.size()]);
+    }
+
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value as a fqn
+     */
+    public String[] ${attribute.name}AsFqn() {
+
+        List<String> result = new ArrayList<>();
+        for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            result.add( TypeUtils.TypeConversion.convertToFqn((TypeMirror)value.getValue()));
+        }
+
+        return result.toArray(new String[result.size()]);
+    }
+!{/if}!{if attribute.isAnnotationType}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public AnnotationMirror[] ${attribute.name}AsAnnotationMirrorArray() {
+        List<AnnotationMirror> result = new ArrayList<>();
+        for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            result.add( ((AnnotationMirror)value.getValue()));
+        }
+
+        return result.toArray(new AnnotationMirror[result.size()]);
+    }
+
+!{if attribute.isWrappedAnnotationType}
+    /**
+     * Gets the ${atw.simpleName}.${attribute.name} from wrapped annotation.
+     * @return the attribute value
+     */
+    public ${attribute.targetWrapperAnnotationName}[] ${attribute.name}() {
+        List<${attribute.targetWrapperAnnotationName}> result = new ArrayList<>();
+        for(AnnotationValue value : (List<AnnotationValue>)AnnotationUtils.getAnnotationValueOfAttributeWithDefaults(annotationMirror, "${attribute.name}").getValue() ) {
+            result.add( ${attribute.targetWrapperAnnotationName}.wrapAnnotationMirror((AnnotationMirror)value.getValue()));
+        }
+
+        return result.toArray(new ${attribute.targetWrapperAnnotationName}[result.size()]);
+    }
+!{/if}
+!{/if}!{/if}
+
+!{if attribute.isOptional}
+    /**
+     * Allows to check if attribute was explicitly set or if default value is used.
+     * @return true, if default value is used, otherwise false
+     */
+    public boolean ${attribute.name}IsDefaultValue(){
+        return AnnotationUtils.getAnnotationValueOfAttribute(annotationMirror,"${attribute.name}") == null;
+    }
+!{/if}
+!{/for}
+
+    /**
+     * Checks if passed element is annotated with this wrapper annotation type : ${atw.simpleName}
+     * @return true, if passed element is annotated with ${atw.simpleName} annotation, otherwise false
+     */
+    public static boolean isAnnotated(Element element) {
+        return element != null && element.getAnnotation(${atw.simpleName}.class) != null;
+    }
+
+     /**
+      * Gets the AnnotationMirror from passed element for this wrappers annotation type and creates a wrapper instance.
+      *
+      * @return The wrapped AnnotationMirror if Element is annotated with this wrappers annotation type, otherwise null.
+      */
+    public static ${atw.simpleName}Wrapper wrapAnnotationOfElement(Element element) {
+        return isAnnotated(element) ? new ${atw.simpleName}Wrapper(element) : null;
+    }
+
+    /**
+     * Wraps an AnnotationMirror.
+     * Throws an IllegalArgumentException if passed AnnotationMirror type doesn't match the wrapped annotation type.
+     *
+     * @return The wrapper instance
+     */
+    public static ${atw.simpleName}Wrapper wrapAnnotationMirror(AnnotationMirror annotationMirror) {
+        return new ${atw.simpleName}Wrapper(annotationMirror);
+    }
+
+}

--- a/annotationwrapper/processor/src/test/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/AnnotationWrapperProcessorTest.java
+++ b/annotationwrapper/processor/src/test/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/AnnotationWrapperProcessorTest.java
@@ -1,0 +1,612 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.processor;
+
+import io.toolisticon.annotationprocessortoolkit.cute.APTKUnitTestProcessor;
+import io.toolisticon.annotationprocessortoolkit.cute.APTKUnitTestProcessorForTestingAnnotationProcessors;
+import io.toolisticon.annotationprocessortoolkit.tools.MessagerUtils;
+import io.toolisticon.annotationprocessortoolkit.tools.corematcher.CoreMatchers;
+import io.toolisticon.annotationprocessortoolkit.tools.fluentfilter.FluentElementFilter;
+import io.toolisticon.cute.CompileTestBuilder;
+import io.toolisticon.cute.PassIn;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AnnotationWrapperProcessorTest {
+
+
+    @Before
+    public void init() {
+        MessagerUtils.setPrintMessageCodes(true);
+    }
+
+
+    @Test
+    public void test_wrapperCreation() {
+        CompileTestBuilder.compilationTest()
+                .addProcessors(AnnotationWrapperProcessor.class)
+                .addSources("testcase/common/TestAnnotation.java", "testcase/common/EmbeddedAnnotation.java", "testcase/common/TestEnum.java", "testcase/withWrappingOfEmbedded/package-info.java")
+                .expectThatJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.annotationprocessortoolkit.wrapper.test.TestAnnotationWrapper", JavaFileObject.Kind.SOURCE)
+                .expectThatJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.annotationprocessortoolkit.wrapper.test.EmbeddedAnnotationWrapper", JavaFileObject.Kind.SOURCE)
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    @Test
+    public void test_wrapperCreationWithoutAutoDiscoveryForEmbeddedAnnotations() {
+        CompileTestBuilder.compilationTest()
+                .addProcessors(AnnotationWrapperProcessor.class)
+                .addSources("testcase/common/TestAnnotation.java", "testcase/common/EmbeddedAnnotation.java", "testcase/common/TestEnum.java", "testcase/withoutWrappingOfEmbedded/package-info.java")
+                .expectThatJavaFileObjectExists(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.annotationprocessortoolkit.wrapper.test.TestAnnotationWrapper", JavaFileObject.Kind.SOURCE)
+                .expectThatJavaFileObjectDoesntExist(StandardLocation.SOURCE_OUTPUT, "io.toolisticon.annotationprocessortoolkit.wrapper.test.EmbeddedAnnotationWrapper", JavaFileObject.Kind.SOURCE)
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+
+    @Test
+    public void test_() {
+        CompileTestBuilder.unitTest().<AnnotationWrapperProcessor, TypeElement>defineTestWithPassedInElement(AnnotationWrapperProcessor.class, UnitTestAnnotation.class, new APTKUnitTestProcessorForTestingAnnotationProcessors<AnnotationWrapperProcessor, TypeElement>() {
+            @Override
+            public void aptkUnitTest(AnnotationWrapperProcessor unit, ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getSimpleName() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTest(new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                AnnotationWrapperProcessor.AnnotationToWrap unit = new AnnotationWrapperProcessor.AnnotationToWrap(UnitTestAnnotation.class.getCanonicalName(), new ArrayList<AnnotationWrapperProcessor.AnnotationAttribute>());
+
+                MatcherAssert.assertThat(unit.getSimpleName(), Matchers.is(UnitTestAnnotation.class.getSimpleName()));
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getQualifiedName() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTest(new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                AnnotationWrapperProcessor.AnnotationToWrap unit = new AnnotationWrapperProcessor.AnnotationToWrap(UnitTestAnnotation.class.getCanonicalName(), new ArrayList<AnnotationWrapperProcessor.AnnotationAttribute>());
+
+                MatcherAssert.assertThat(unit.getQualifiedName(), Matchers.is(UnitTestAnnotation.class.getCanonicalName()));
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getImports() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTest(new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                AnnotationWrapperProcessor.AnnotationAttribute attribute1 = Mockito.mock(AnnotationWrapperProcessor.AnnotationAttribute.class);
+                Mockito.when(attribute1.getImport()).thenReturn(Serializable.class.getCanonicalName());
+
+                AnnotationWrapperProcessor.AnnotationAttribute attribute2 = Mockito.mock(AnnotationWrapperProcessor.AnnotationAttribute.class);
+                Mockito.when(attribute2.getImport()).thenReturn(Collections.class.getCanonicalName());
+
+                List<AnnotationWrapperProcessor.AnnotationAttribute> attributes = Arrays.asList(attribute1, attribute2);
+
+                AnnotationWrapperProcessor.AnnotationToWrap unit = new AnnotationWrapperProcessor.AnnotationToWrap(UnitTestAnnotation.class.getCanonicalName(), attributes);
+
+                MatcherAssert.assertThat(unit.getImports(), Matchers.containsInAnyOrder(UnitTestAnnotation.class.getCanonicalName(), Serializable.class.getCanonicalName(), Collections.class.getCanonicalName()));
+
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getAttributes() {
+
+        AnnotationWrapperProcessor.AnnotationAttribute attribute1 = Mockito.mock(AnnotationWrapperProcessor.AnnotationAttribute.class);
+        Mockito.when(attribute1.getImport()).thenReturn(Serializable.class.getCanonicalName());
+
+        AnnotationWrapperProcessor.AnnotationAttribute attribute2 = Mockito.mock(AnnotationWrapperProcessor.AnnotationAttribute.class);
+        Mockito.when(attribute2.getImport()).thenReturn(Collections.class.getCanonicalName());
+
+        List<AnnotationWrapperProcessor.AnnotationAttribute> attributes = Arrays.asList(attribute1, attribute2);
+
+        AnnotationWrapperProcessor.AnnotationToWrap unit = new AnnotationWrapperProcessor.AnnotationToWrap(UnitTestAnnotation.class.getCanonicalName(), attributes);
+
+        MatcherAssert.assertThat(unit.getAttributes(), Matchers.is(attributes));
+
+    }
+
+
+    @PassIn
+    @interface UnitTestAnnotation {
+        String stringAttribute();
+
+        long longAttribute();
+
+        double doubleAttribute();
+
+        Class<?> typeAttribute();
+
+        TypeKind enumAttribute();
+
+        UnitTestEmbeddedAnnotation annotationAttribute();
+
+        String[] stringArrayAttribute() default {};
+
+        TypeKind[] enumArrayAttribute();
+
+        Class<?>[] typeArrayAttribute();
+
+        UnitTestEmbeddedAnnotation[] annotationArrayAttribute();
+    }
+
+    @interface UnitTestEmbeddedAnnotation {
+        long value();
+    }
+
+
+    @Test
+    public void test_AnnotationToWrap_getAttributeType() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_getAttributeType(typeElement, "stringAttribute", String.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "longAttribute", long.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "doubleAttribute", double.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "typeAttribute", Class.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "enumAttribute", TypeKind.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "annotationAttribute", UnitTestEmbeddedAnnotation.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "stringArrayAttribute", String.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "enumArrayAttribute", TypeKind.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "typeArrayAttribute", Class.class);
+                test_AnnotationToWrap_getAttributeType(typeElement, "annotationArrayAttribute", UnitTestEmbeddedAnnotation.class);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_getAttributeType(TypeElement typeElement, String name, Class<?> expectedType) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.getAttributeType(), Matchers.is(expectedType.getSimpleName()));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getComponentAttributeType() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_getComponentAttributeType(typeElement, "stringArrayAttribute", String.class);
+                test_AnnotationToWrap_getComponentAttributeType(typeElement, "enumArrayAttribute", TypeKind.class);
+                test_AnnotationToWrap_getComponentAttributeType(typeElement, "typeArrayAttribute", Class.class);
+                test_AnnotationToWrap_getComponentAttributeType(typeElement, "annotationArrayAttribute", UnitTestEmbeddedAnnotation.class);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_getComponentAttributeType(TypeElement typeElement, String name, Class<?> expectedType) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.getComponentAttributeType(), Matchers.is(expectedType.getSimpleName()));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getImport() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_getImport(typeElement, "stringAttribute", null);
+                test_AnnotationToWrap_getImport(typeElement, "longAttribute", null);
+                test_AnnotationToWrap_getImport(typeElement, "doubleAttribute", null);
+                test_AnnotationToWrap_getImport(typeElement, "typeAttribute", null);
+                test_AnnotationToWrap_getImport(typeElement, "enumAttribute", TypeKind.class.getCanonicalName());
+                test_AnnotationToWrap_getImport(typeElement, "annotationAttribute", UnitTestEmbeddedAnnotation.class.getCanonicalName());
+                test_AnnotationToWrap_getImport(typeElement, "stringArrayAttribute", null);
+                test_AnnotationToWrap_getImport(typeElement, "enumArrayAttribute", TypeKind.class.getCanonicalName());
+                test_AnnotationToWrap_getImport(typeElement, "typeArrayAttribute", null);
+                test_AnnotationToWrap_getImport(typeElement, "annotationArrayAttribute", UnitTestEmbeddedAnnotation.class.getCanonicalName());
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_getImport(TypeElement typeElement, String name, String expectedImport) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.getImport(), Matchers.is(expectedImport));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getName() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_getName(typeElement, "stringAttribute");
+                test_AnnotationToWrap_getName(typeElement, "longAttribute");
+                test_AnnotationToWrap_getName(typeElement, "doubleAttribute");
+                test_AnnotationToWrap_getName(typeElement, "typeAttribute");
+                test_AnnotationToWrap_getName(typeElement, "enumAttribute");
+                test_AnnotationToWrap_getName(typeElement, "annotationAttribute");
+                test_AnnotationToWrap_getName(typeElement, "stringArrayAttribute");
+                test_AnnotationToWrap_getName(typeElement, "enumArrayAttribute");
+                test_AnnotationToWrap_getName(typeElement, "typeArrayAttribute");
+                test_AnnotationToWrap_getName(typeElement, "annotationArrayAttribute");
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_getName(TypeElement typeElement, String name) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.getName(), Matchers.is(name));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getWrappedTypeMirror() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "stringAttribute", String.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "longAttribute", long.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "doubleAttribute", double.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "typeAttribute", Class.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "enumAttribute", TypeKind.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "annotationAttribute", UnitTestEmbeddedAnnotation.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "stringArrayAttribute", String.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "enumArrayAttribute", TypeKind.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "typeArrayAttribute", Class.class);
+                test_AnnotationToWrap_getWrappedTypeMirror(typeElement, "annotationArrayAttribute", UnitTestEmbeddedAnnotation.class);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_getWrappedTypeMirror(TypeElement typeElement, String name, Class<?> expectedType) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.getWrappedTypeMirror().getQualifiedName(), Matchers.is(expectedType.getCanonicalName()));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_isAnnotationType() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_isAnnotationType(typeElement, "stringAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "longAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "doubleAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "typeAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "enumAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "annotationAttribute", true);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "stringArrayAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "enumArrayAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "typeArrayAttribute", false);
+                test_AnnotationToWrap_isAnnotationType(typeElement, "annotationArrayAttribute", true);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_isAnnotationType(TypeElement typeElement, String name, boolean expectedResult) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.isAnnotationType(), Matchers.is(expectedResult));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_isArray() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_isArray(typeElement, "stringAttribute", false);
+                test_AnnotationToWrap_isArray(typeElement, "longAttribute", false);
+                test_AnnotationToWrap_isArray(typeElement, "doubleAttribute", false);
+                test_AnnotationToWrap_isArray(typeElement, "typeAttribute", false);
+                test_AnnotationToWrap_isArray(typeElement, "enumAttribute", false);
+                test_AnnotationToWrap_isArray(typeElement, "annotationAttribute", false);
+                test_AnnotationToWrap_isArray(typeElement, "stringArrayAttribute", true);
+                test_AnnotationToWrap_isArray(typeElement, "enumArrayAttribute", true);
+                test_AnnotationToWrap_isArray(typeElement, "typeArrayAttribute", true);
+                test_AnnotationToWrap_isArray(typeElement, "annotationArrayAttribute", true);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_isArray(TypeElement typeElement, String name, boolean expectedResult) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.isArray(), Matchers.is(expectedResult));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_isClass() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_isClass(typeElement, "stringAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "longAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "doubleAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "typeAttribute", true);
+                test_AnnotationToWrap_isClass(typeElement, "enumAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "annotationAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "stringArrayAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "enumArrayAttribute", false);
+                test_AnnotationToWrap_isClass(typeElement, "typeArrayAttribute", true);
+                test_AnnotationToWrap_isClass(typeElement, "annotationArrayAttribute", false);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_isClass(TypeElement typeElement, String name, boolean expectedResult) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.isClass(), Matchers.is(expectedResult));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_isEnum() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_isEnum(typeElement, "stringAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "longAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "doubleAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "typeAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "enumAttribute", true);
+                test_AnnotationToWrap_isEnum(typeElement, "annotationAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "stringArrayAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "enumArrayAttribute", true);
+                test_AnnotationToWrap_isEnum(typeElement, "typeArrayAttribute", false);
+                test_AnnotationToWrap_isEnum(typeElement, "annotationArrayAttribute", false);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_isEnum(TypeElement typeElement, String name, boolean expectedResult) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.isEnum(), Matchers.is(expectedResult));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_isPrimitiveOrString() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "stringAttribute", true);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "longAttribute", true);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "doubleAttribute", true);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "typeAttribute", false);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "enumAttribute", false);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "annotationAttribute", false);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "stringArrayAttribute", true);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "enumArrayAttribute", false);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "typeArrayAttribute", false);
+                test_AnnotationToWrap_isPrimitiveOrString(typeElement, "annotationArrayAttribute", false);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_isPrimitiveOrString(TypeElement typeElement, String name, boolean expectedResult) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.isPrimitiveOrString(), Matchers.is(expectedResult));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_isOptional() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_isOptional(typeElement, "stringAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "longAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "doubleAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "typeAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "enumAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "annotationAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "stringArrayAttribute", true);
+                test_AnnotationToWrap_isOptional(typeElement, "enumArrayAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "typeArrayAttribute", false);
+                test_AnnotationToWrap_isOptional(typeElement, "annotationArrayAttribute", false);
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_isOptional(TypeElement typeElement, String name, boolean expectedResult) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        MatcherAssert.assertThat(unit.isOptional(), Matchers.is(expectedResult));
+
+        // make sure that there are no interactions with state
+        Mockito.verifyZeroInteractions(state);
+
+    }
+
+    @Test
+    public void test_AnnotationToWrap_getTargetWrapperAnnotationName() {
+        CompileTestBuilder.unitTest().<TypeElement>defineTestWithPassedInElement(UnitTestAnnotation.class, new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest(ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                test_AnnotationToWrap_getTargetWrapperAnnotationName(typeElement, "annotationAttribute", UnitTestEmbeddedAnnotation.class.getCanonicalName());
+                test_AnnotationToWrap_getTargetWrapperAnnotationName(typeElement, "annotationArrayAttribute", UnitTestEmbeddedAnnotation.class.getCanonicalName());
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+    }
+
+    private void test_AnnotationToWrap_getTargetWrapperAnnotationName(TypeElement typeElement, String name, String expectedCanonicalName) {
+
+        AnnotationWrapperProcessor.State state = Mockito.mock(AnnotationWrapperProcessor.State.class);
+        ExecutableElement executableElement = getExecutableElement(typeElement, name);
+
+        AnnotationWrapperProcessor.AnnotationAttribute unit = new AnnotationWrapperProcessor.AnnotationAttribute(state, executableElement);
+
+        unit.getTargetWrapperAnnotationName();
+
+        // make sure that there are no interactions with state
+        Mockito.verify(state).getWrapperName(Mockito.eq(expectedCanonicalName));
+
+    }
+
+    private ExecutableElement getExecutableElement(TypeElement typeElement, String name) {
+        return FluentElementFilter.createFluentElementFilter(typeElement.getEnclosedElements())
+                .applyFilter(CoreMatchers.IS_METHOD)
+                .applyFilter(CoreMatchers.BY_NAME).filterByOneOf(name)
+                .getResult().get(0);
+    }
+}

--- a/annotationwrapper/processor/src/test/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/WrapperAnnotationProcessorMessagesTest.java
+++ b/annotationwrapper/processor/src/test/java/io/toolisticon/annotationprocessortoolkit/wrapper/processor/WrapperAnnotationProcessorMessagesTest.java
@@ -1,0 +1,21 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.processor;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link AnnotationWrapperProcessorMessages}.
+ * <p>
+ */
+public class WrapperAnnotationProcessorMessagesTest {
+
+    @Test
+    public void test_enum() {
+
+        MatcherAssert.assertThat(AnnotationWrapperProcessorMessages.ERROR_CANT_CREATE_WRAPPER.getCode(), Matchers.is("ANNOTATION_WRAPPER_ERROR_001"));
+        MatcherAssert.assertThat(AnnotationWrapperProcessorMessages.ERROR_CANT_CREATE_WRAPPER.getMessage(), Matchers.notNullValue());
+    }
+
+
+}

--- a/annotationwrapper/processor/src/test/resources/testcase/common/EmbeddedAnnotation.java
+++ b/annotationwrapper/processor/src/test/resources/testcase/common/EmbeddedAnnotation.java
@@ -1,0 +1,9 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmbeddedAnnotation {
+    long value();
+}

--- a/annotationwrapper/processor/src/test/resources/testcase/common/TestAnnotation.java
+++ b/annotationwrapper/processor/src/test/resources/testcase/common/TestAnnotation.java
@@ -1,0 +1,34 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TestAnnotation {
+
+    String stringAttribute();
+
+    long longAttribute();
+
+    double doubleAttribute();
+
+    Class<?> typeAttribute();
+
+    TestEnum enumAttribute();
+
+    EmbeddedAnnotation annotationAttribute();
+
+    String[] stringArrayAttribute() default {};
+
+    TestEnum[] enumArrayAttribute();
+
+    Class<?>[] typeArrayAttribute();
+
+    EmbeddedAnnotation[] annotationArrayAttribute();
+
+}

--- a/annotationwrapper/processor/src/test/resources/testcase/common/TestEnum.java
+++ b/annotationwrapper/processor/src/test/resources/testcase/common/TestEnum.java
@@ -1,0 +1,5 @@
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+public enum TestEnum {
+    ONE, TWO, THREE;
+}

--- a/annotationwrapper/processor/src/test/resources/testcase/withWrappingOfEmbedded/package-info.java
+++ b/annotationwrapper/processor/src/test/resources/testcase/withWrappingOfEmbedded/package-info.java
@@ -1,0 +1,7 @@
+@AnnotationWrapper(value = {TestAnnotation.class},automaticallyWrapEmbeddedAnnotations = true)
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import io.toolisticon.annotationprocessortoolkit.wrapper.api.AnnotationWrapper;
+
+
+

--- a/annotationwrapper/processor/src/test/resources/testcase/withoutWrappingOfEmbedded/package-info.java
+++ b/annotationwrapper/processor/src/test/resources/testcase/withoutWrappingOfEmbedded/package-info.java
@@ -1,0 +1,7 @@
+@AnnotationWrapper(value = {TestAnnotation.class},automaticallyWrapEmbeddedAnnotations = false)
+package io.toolisticon.annotationprocessortoolkit.wrapper.test;
+
+import io.toolisticon.annotationprocessortoolkit.wrapper.api.AnnotationWrapper;
+
+
+

--- a/cute/src/main/java/io/toolisticon/annotationprocessortoolkit/cute/APTKUnitTestProcessor.java
+++ b/cute/src/main/java/io/toolisticon/annotationprocessortoolkit/cute/APTKUnitTestProcessor.java
@@ -1,0 +1,44 @@
+package io.toolisticon.annotationprocessortoolkit.cute;
+
+import io.toolisticon.annotationprocessortoolkit.ToolingProvider;
+import io.toolisticon.cute.UnitTest;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+
+/**
+ * Convenient unit test processor for unit testing code based on APTK with toolisticon's compiletesting framework.
+ */
+public abstract class APTKUnitTestProcessor<ELEMENT_TYPE extends Element> implements UnitTest<ELEMENT_TYPE> {
+
+    /**
+     * The original unit test processor method. Contains logic to initialize the ToolingProvider.
+     * Will be called by compiletesting framework. Propagates call to aptkUnitTest method after initializations.
+     *
+     * @param processingEnvironment the processing environment
+     * @param typeElement           the default typeElement
+     */
+    @Override
+    public final void unitTest(ProcessingEnvironment processingEnvironment, ELEMENT_TYPE typeElement) {
+
+        try {
+            // do initializations
+            ToolingProvider.setTooling(processingEnvironment);
+
+            // propagate to unit test implementation
+            this.aptkUnitTest(processingEnvironment, typeElement);
+
+        } finally {
+            ToolingProvider.clearTooling();
+        }
+
+    }
+
+    /**
+     * The unit test method.
+     *
+     * @param processingEnvironment the processingEnvironment
+     * @param typeElement           the element the underlying annotation processor is applied on
+     */
+    public abstract void aptkUnitTest(ProcessingEnvironment processingEnvironment, ELEMENT_TYPE typeElement);
+}

--- a/cute/src/test/java/io/toolisticon/annotationprocessortoolkit/cute/APTKUnitTestProcessorTest.java
+++ b/cute/src/test/java/io/toolisticon/annotationprocessortoolkit/cute/APTKUnitTestProcessorTest.java
@@ -1,0 +1,48 @@
+package io.toolisticon.annotationprocessortoolkit.cute;
+
+import io.toolisticon.annotationprocessortoolkit.AbstractAnnotationProcessor;
+import io.toolisticon.annotationprocessortoolkit.ToolingProvider;
+import io.toolisticon.cute.CompileTestBuilder;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+import java.util.Set;
+
+/**
+ * Unit test for {@link APTKUnitTestProcessor}.
+ */
+public class APTKUnitTestProcessorTest {
+
+    private static boolean unitTestMethodCalled = false;
+
+
+
+    @Test
+    public void testIfToolingIsSetCorrectly() {
+
+        CompileTestBuilder.unitTest().defineTest( new APTKUnitTestProcessor<TypeElement>() {
+            @Override
+            public void aptkUnitTest( ProcessingEnvironment processingEnvironment, TypeElement typeElement) {
+
+                unitTestMethodCalled = true;
+
+                MatcherAssert.assertThat(ToolingProvider.getTooling(), Matchers.notNullValue());
+
+            }
+        })
+                .compilationShouldSucceed()
+                .executeTest();
+
+
+        // check if init was called
+        MatcherAssert.assertThat("aptkUnitTest method must have been called", unitTestMethodCalled);
+
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,9 @@
         <module>example</module>
         <module>templating</module>
 
+        <!-- wrapper processor -->
+        <module>annotationwrapper</module>
+
         <!-- support for toolisticon cute -->
         <module>cute</module>
 
@@ -87,7 +90,7 @@
 
         <java.version>1.7</java.version>
 
-        <spiap.version>0.7.0</spiap.version>
+        <spiap.version>0.8.0</spiap.version>
         <cute.version>0.11.1</cute.version>
 
         <!-- versions of test dependencies -->

--- a/templating/src/main/java/io/toolisticon/annotationprocessortoolkit/templating/templateblocks/IfTemplateBlock.java
+++ b/templating/src/main/java/io/toolisticon/annotationprocessortoolkit/templating/templateblocks/IfTemplateBlock.java
@@ -49,8 +49,8 @@ public class IfTemplateBlock implements TemplateBlock {
         Expression expression = ExpressionParser.parseExpression(accessPath, outerVariables);
         Operand result = expression.evaluateExpression();
 
-        if (!Boolean.class.equals(result.getOperandsJavaType())) {
-            throw new InvalidExpressionResult("If statements expression '" + accessPath + "' must evaluate to Boolean" + (result.getOperandsJavaType() != null ? ", but is of type " + result.getOperandsJavaType().getCanonicalName() : ""));
+        if (!Boolean.class.equals(result.getOperandsJavaType()) && !boolean.class.equals(result.getOperandsJavaType())) {
+            throw new InvalidExpressionResult("If statements expression '" + accessPath + "' must evaluate to Boolean or boolean " + (result.getOperandsJavaType() != null ? ", but is of type " + result.getOperandsJavaType().getCanonicalName() : ""));
         }
 
         if ((Boolean) result.value()) {


### PR DESCRIPTION
This is quite useful if there is a class based attribute in the annotation, which is often the case.

Reading of attribute values will be similar to use the annotation type directly!

Class based attributes will then be accessible as TypeMirror, FQN String ot TypeMirrorWrapper.

Embedded annotations can be configured to be automatically wrapped as well if not explicitly configured added at the AnnotationWrapper annotation.